### PR TITLE
Response cache storage

### DIFF
--- a/packages/api/src/models/ClobbrLog.ts
+++ b/packages/api/src/models/ClobbrLog.ts
@@ -24,7 +24,7 @@ export interface ClobbrLogItemMeta {
   duration?: number;
   durationUnit?: string;
   size?: string;
-  data?: { [key: string]: string };
+  data?: { [key: string]: string } | string;
 }
 
 export interface ClobbrLogItemFailedMessage {

--- a/packages/ui/src/apihustle/apihustle-group.jsx
+++ b/packages/ui/src/apihustle/apihustle-group.jsx
@@ -37,11 +37,13 @@ export const ApiHustleGroup = ({
       >
         <li
           className={clsx(
-            'flex gap-3 items-center relative',
+            'flex gap-3 items-center relative group',
             layout === 'horizontal' ? 'flex-col text-xs' : ''
           )}
         >
-          <ClobbrAppLogo className={'w-14'} />
+          <ClobbrAppLogo
+            className={'w-14 group-hover:grayscale transition-all'}
+          />
 
           <div>
             <h3>Clobbr</h3>
@@ -70,7 +72,7 @@ export const ApiHustleGroup = ({
               href="https://clobbr.app"
               target="_blank"
               rel="noopener noreferrer"
-              className="absolute inset-0 hover:backdrop-grayscale transition-all"
+              className="absolute inset-0 transition-all"
             >
               <span className="opacity-0">Visit Clobbr</span>
             </a>
@@ -79,11 +81,13 @@ export const ApiHustleGroup = ({
 
         <li
           className={clsx(
-            'flex gap-3 items-center relative',
+            'flex gap-3 items-center relative group',
             layout === 'horizontal' ? 'flex-col text-xs' : ''
           )}
         >
-          <CrontapAppLogo className={'w-14'} />
+          <CrontapAppLogo
+            className={'w-14 group-hover:grayscale transition-all'}
+          />
 
           <div>
             <h3>Crontap</h3>
@@ -112,7 +116,7 @@ export const ApiHustleGroup = ({
               href="https://crontap.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="absolute inset-0 hover:backdrop-grayscale transition-all"
+              className="absolute inset-0 transition-all"
             >
               <span className="opacity-0">Visit Crontap</span>
             </a>
@@ -121,11 +125,13 @@ export const ApiHustleGroup = ({
 
         <li
           className={clsx(
-            'flex gap-3 items-center relative',
+            'flex gap-3 items-center relative group',
             layout === 'horizontal' ? 'flex-col text-xs' : ''
           )}
         >
-          <CronToolAppLogo className={'w-14'} />
+          <CronToolAppLogo
+            className={'w-14 group-hover:grayscale transition-all'}
+          />
 
           <div>
             <h3>CronTool</h3>
@@ -154,7 +160,7 @@ export const ApiHustleGroup = ({
               href="https://tool.crontap.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="absolute inset-0 hover:backdrop-grayscale transition-all"
+              className="absolute inset-0 transition-all"
             >
               <span className="opacity-0">Visit CronTool</span>
             </a>

--- a/packages/ui/src/models/ClobbrUICachedLog.ts
+++ b/packages/ui/src/models/ClobbrUICachedLog.ts
@@ -1,0 +1,4 @@
+export interface ClobbrUICachedLog {
+  index: number;
+  data?: { [key: string]: string } | string;
+}

--- a/packages/ui/src/models/ClobbrUIResult.ts
+++ b/packages/ui/src/models/ClobbrUIResult.ts
@@ -3,6 +3,7 @@ import { ClobbrLogItem } from '@clobbr/api/src/models/ClobbrLog';
 
 export interface ClobbrUIResult {
   id: string;
+  cachedId: string;
   startDate?: string;
   endDate?: string;
   resultDurations: Array<number>;

--- a/packages/ui/src/results/ResultHistory/ResultHistoryResponses/ResultHistoryResponse.tsx
+++ b/packages/ui/src/results/ResultHistory/ResultHistoryResponses/ResultHistoryResponse.tsx
@@ -8,6 +8,7 @@ import { getDurationColorClass } from 'shared/util/getDurationColorClass';
 
 import { ClobbrUIResult } from 'models/ClobbrUIResult';
 import { ResultHistoryResponseViewer } from 'results/ResultHistory/ResultHistoryResponses/ResultHistoryResponseViewer';
+import { getResultLogsKey } from 'shared/util/getResultLogsKey';
 
 export const ResultHistoryResponse = ({
   className,
@@ -31,6 +32,9 @@ export const ResultHistoryResponse = ({
   };
 
   const openLog = isNumber(openLogIndex) ? result.logs[openLogIndex] : null;
+  const logKey = getResultLogsKey({
+    cachedId: result.cachedId
+  });
 
   return (
     <div className={clsx('flex', className)}>
@@ -97,7 +101,7 @@ export const ResultHistoryResponse = ({
       </ul>
 
       {openLog ? (
-        <ResultHistoryResponseViewer log={openLog} />
+        <ResultHistoryResponseViewer log={openLog} logKey={logKey} />
       ) : (
         <Typography variant="caption" className="text-center p-6">
           Select an item to view the response.

--- a/packages/ui/src/shared/util/getResultLogsKey.ts
+++ b/packages/ui/src/shared/util/getResultLogsKey.ts
@@ -1,0 +1,10 @@
+/**
+ * Get the key for the result logs cache.
+ */
+export const getResultLogsKey = ({
+  cachedId
+}: {
+  cachedId: string;
+}): string => {
+  return cachedId;
+};

--- a/packages/ui/src/shared/util/toValidStorageKey.ts
+++ b/packages/ui/src/shared/util/toValidStorageKey.ts
@@ -1,0 +1,8 @@
+export const toValidStorageKeyName = (key: string) => {
+  return key
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/^[._]/, '')
+    .replace(/[^a-z0-9-~]+/g, '-');
+};

--- a/packages/ui/src/storage/EDbStores.ts
+++ b/packages/ui/src/storage/EDbStores.ts
@@ -1,4 +1,5 @@
 export const enum EDbStores {
   MAIN_STORE_NAME = 'main',
-  RESULT_STORE_NAME = 'result'
+  RESULT_STORE_NAME = 'result',
+  RESULT_LOGS_STORE_NAME = 'resultLogs'
 }

--- a/packages/ui/src/storage/storage.ts
+++ b/packages/ui/src/storage/storage.ts
@@ -23,6 +23,12 @@ const resultDb = localforage.createInstance({
   description: 'Holds result data'
 });
 
+const resultResponseDb = localforage.createInstance({
+  name: DB_NAME,
+  storeName: EDbStores.RESULT_LOGS_STORE_NAME,
+  description: 'Holds result response data'
+});
+
 export const getDb = (type: EDbStores) => {
   const _getDb = () => {
     switch (type) {
@@ -30,6 +36,8 @@ export const getDb = (type: EDbStores) => {
         return mainDb;
       case EDbStores.RESULT_STORE_NAME:
         return resultDb;
+      case EDbStores.RESULT_LOGS_STORE_NAME:
+        return resultResponseDb;
       default:
         return mainDb;
     }

--- a/packages/ui/src/storage/storageKeys.ts
+++ b/packages/ui/src/storage/storageKeys.ts
@@ -2,6 +2,9 @@ export const SK = {
   RESULT: {
     LIST: 'result.resultList'
   },
+  RESULT_RESPONSE: {
+    ITEM: 'result.response.item'
+  },
   PREFERENCES: {
     THEME: 'preferences.theme',
     STICKY_SEARCH: 'preferences.stickySearch',


### PR DESCRIPTION
This improves performance by moving result responses to a different indexedDB table.
All logs are stored on the same key and looked up when needed (e.g. viewer)